### PR TITLE
Initial Suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Bash script to launch ChromeOS with Chromebrew in Docker
 
 ## Installation
 ```bash
-$ git clone git@github.com:uberhacker/chromeos-docker.git
+$ git clone https://github.com/uberhacker/chromeos-docker.git
 $ cd chromeos-docker
-$ sudo cp chromeos-docker /usr/local/bin
+$ sudo cp chromeos-docker /usr/local/bin/
 $ cd /path/to/projects
-$ git clone git@github.com:skycocker/chromebrew.git
+$ git clone https://github.com/chromebrew/chromebrew.git
 $ mkdir pkg_cache
 $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```

--- a/chromeos-docker
+++ b/chromeos-docker
@@ -22,7 +22,7 @@ case $1 in
   aarch64|arm|armv7|armv7l|armv8)
     ARCH=armv7l
     BOARD=fievel
-    MILESTONE=m92
+    MILESTONE=m91
     ;;
   i386|i686|ia32|x86)
     ARCH=i686
@@ -32,7 +32,7 @@ case $1 in
   ia64|x64|x86_64)
     ARCH=x86_64
     BOARD=kip
-    MILESTONE=m92
+    MILESTONE=m91
     ;;
   *)
     echo "Usage: $(basename $0) armv7l|i686|x86_64"

--- a/chromeos-docker
+++ b/chromeos-docker
@@ -11,7 +11,7 @@ if [ ! -d $(pwd)/pkg_cache ]; then
 fi
 if [ ! -d $(pwd)/chromebrew ]; then
   echo "$(pwd)/chromebrew directory does not exist."
-  echo "Execute 'git clone git@github.com:skycocker/chromebrew.git' and try again."
+  echo "Execute 'git clone https://github.com/chromebrew/chromebrew.git' and try again."
   exit 1
 fi
 if ! test $1; then


### PR DESCRIPTION
1. Use https for git urls
2. Use the chromebrew/chromebrew urls (I've been syncing this from the skycocker repo every few days.)
3. Use M91 for the base image to be backward compatible with Glibc 2.27 for `armv7l` and `x86_64`. (You're going to have to upload M91 builds of those images.)